### PR TITLE
Add "b.If" and "b.IfElse"

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -47,6 +47,24 @@ func (b *Builder) createElement(tag string, selfClosing bool, args ...interface{
 	return element
 }
 
+// Logic for creating HTML elements
+
+// If returns the Node if the condition is true, otherwise returns nil.
+func (b *Builder) If(condition bool, Node Node) Node {
+	if condition {
+		return Node
+	}
+	return nil
+}
+
+// IfElse returns the trueNode if condition is true, otherwise returns falseNode.
+func (b *Builder) IfElse(condition bool, trueNode, falseNode Node) Node {
+	if condition {
+		return trueNode
+	}
+	return falseNode
+}
+
 // Document structure elements
 
 // Html creates an <html> element.

--- a/minty_test.go
+++ b/minty_test.go
@@ -74,6 +74,27 @@ func TestAttributes(t *testing.T) {
 	}
 }
 
+// Logic test - If works
+func TestIf(t *testing.T) {
+	template := func(b *Builder) Node {
+		return b.Div(
+			b.If(true, b.P("Condition is true")),
+			b.If(false, b.P("Condition is false")),
+		)
+	}
+
+	var buf bytes.Buffer
+	Render(template, &buf)
+	html := buf.String()
+
+	if !strings.Contains(html, "Condition is true") {
+		t.Error("If(true) did not render content")
+	}
+	if strings.Contains(html, "Condition is false") {
+		t.Error("If(false) should not render content")
+	}
+}
+
 // Builder regression test - global instance works
 func TestGlobalBuilder(t *testing.T) {
 	template := func(b *Builder) Node {


### PR DESCRIPTION
This makes it a bit easier to assemble conditional Nodes.

              return b.Div(
                       b.If(true, b.P("Condition is true")),
                       b.If(false, b.P("Condition is false")),
               )

This might conflict with a future `<if>` tag, and `<ifelse>` if HTML ever adds them...

Maybe they should have a different name, or live elsewhere?