### PR TITLE
Ignore <nil> values

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -18,6 +18,9 @@ func (b *Builder) createElement(tag string, selfClosing bool, args ...interface{
 	}
 
 	for _, arg := range args {
+		if arg == nil {
+			continue
+		}
 		switch v := arg.(type) {
 		case Attribute:
 			v.Apply(element)

--- a/minty_test.go
+++ b/minty_test.go
@@ -87,11 +87,11 @@ func TestIf(t *testing.T) {
 	Render(template, &buf)
 	html := buf.String()
 
-	if !strings.Contains(html, "Condition is true") {
-		t.Error("If(true) did not render content")
+	if !strings.Contains(html, "<div><p>Condition is true</p></div>") {
+		t.Errorf("If(true) should render content, got: %s", html)
 	}
-	if strings.Contains(html, "Condition is false") {
-		t.Error("If(false) should not render content")
+	if strings.Contains(html, "<div><p>Condition is false</p></div>") {
+		t.Errorf("If(false) should not render content, got: %s", html)
 	}
 }
 


### PR DESCRIPTION
I feel the zero value of a pointer should yield nothing when rendered.

Without this, the "else" clause of "if" renders `&lt;nil&gt`

```
minty_test.go:91: If(true) should render content, got: <div><p>Condition is true</p>&lt;nil&gt;</div>
```