### PR TITLE
Support recursive if and if-else

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -18,9 +18,21 @@ func (b *Builder) createElement(tag string, selfClosing bool, args ...interface{
 	}
 
 	for _, arg := range args {
+		for range 100 { // break out of infinite loops
+			if eval, ok := arg.(Evaluation); ok {
+				if eval.condition {
+					arg = eval.trueValue
+				} else {
+					arg = eval.falseValue
+				}
+				continue
+			}
+		}
+
 		if arg == nil {
 			continue
 		}
+
 		switch v := arg.(type) {
 		case Attribute:
 			v.Apply(element)
@@ -51,21 +63,27 @@ func (b *Builder) createElement(tag string, selfClosing bool, args ...interface{
 }
 
 // Logic for creating HTML elements
+type Evaluation struct {
+	condition  bool
+	trueValue  any
+	falseValue any
+}
 
 // If returns the Node if the condition is true, otherwise returns nil.
-func (b *Builder) If(condition bool, Node Node) Node {
-	if condition {
-		return Node
+func (b *Builder) If(condition bool, item any) Evaluation {
+	return Evaluation{
+		condition: condition,
+		trueValue: item,
 	}
-	return nil
 }
 
 // IfElse returns the trueNode if condition is true, otherwise returns falseNode.
-func (b *Builder) IfElse(condition bool, trueNode, falseNode Node) Node {
-	if condition {
-		return trueNode
+func (b *Builder) IfElse(condition bool, trueNode, falseNode any) Evaluation {
+	return Evaluation{
+		condition:  condition,
+		trueValue:  trueNode,
+		falseValue: falseNode,
 	}
-	return falseNode
 }
 
 // Document structure elements


### PR DESCRIPTION
Hi Ha1tch!  Bit of a lull lately, but I managed to squeeze in this change.  I'm not super happy with the "for 100", but I don't see a way around that to avoid potential endless loops in case of an incorrectly created tree.  This change moves the evaluation of the If from _contstruction_ time to _render_ time, i.e. the Render func now discovers and "flattens" trees of If and IfElse nodes.

This allows nesting if and if/else without problems.

The following sets the class to "yes" if condition, and "no" if otherCondition, but nothing if both are false

    b.Div(b.IfElse(condition, mi.Class("yes"),
        b.If(otherCondition, mi.Class("no"))))

Previously this would render `<nil>` or other garbage to the HTML.

I was wondering if I should write a go Iterator to loop over the items, and replace the items on-the-fly instead of the special handling that If now gets in the main rendering loop.  Let me know and I could give it a shot.  Not sure if it would bring any clarity though.  Maybe there are other nodes that could use replacing in future?
